### PR TITLE
feat: add remaining `jsx-a11y` rules to the preset

### DIFF
--- a/jsx-a11y.js
+++ b/jsx-a11y.js
@@ -32,5 +32,39 @@ module.exports = {
     "jsx-a11y/lang": "error",
     "jsx-a11y/media-has-caption": "error",
     "jsx-a11y/mouse-events-have-key-events": "error",
+    "jsx-a11y/no-access-key": "error",
+    "jsx-a11y/no-autofocus": "error",
+    "jsx-a11y/no-distracting-elements": "error",
+    "jsx-a11y/no-interactive-element-to-noninteractive-role": "warn", // not sure I understand what this rule does, but seems useful
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": "warn", // not sure I understand what this rule does, but seems useful
+    "jsx-a11y/no-noninteractive-element-interactions": "warn", // not sure I understand what this rule does, but seems useful
+    "jsx-a11y/no-noninteractive-tabindex": [
+      "error",
+      {
+        tags: [],
+        roles: ["tabpanel"],
+        allowExpressionValues: true,
+      },
+    ],
+    "jsx-a11y/no-redundant-roles": "error",
+    "jsx-a11y/no-static-element-interactions": [
+      "warn",
+      {
+        handlers: [
+          "onClick",
+          "onMouseDown",
+          "onMouseUp",
+          "onKeyPress",
+          "onKeyDown",
+          "onKeyUp",
+        ],
+        allowExpressionValues: true,
+      },
+    ],
+    "jsx-a11y/prefer-tag-over-role": "error",
+    "jsx-a11y/role-has-required-aria-props": "warn",
+    "jsx-a11y/role-supports-aria-props": "warn",
+    "jsx-a11y/scope": "warn",
+    "jsx-a11y/tabindex-no-positive": "warn",
   },
 }


### PR DESCRIPTION
Include all supported `jsx-a11y` rules to the preset.