### PR TITLE
fix: autodetect react version in `eslint-plugin-react` settings

### DIFF
--- a/react.js
+++ b/react.js
@@ -11,6 +11,11 @@ module.exports = {
       jsx: true,
     },
   },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
   rules: {
     // Recommended rules: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/configs/recommended.js
     "react/display-name": "error",


### PR DESCRIPTION
Fixes #8
This fixes the CLI warning which says that React version is not specified. 