### PR TITLE
ci: use node version from `.nvmrc`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN_SEMANTIC_RELEASE }}
+      - name: Get Node.js version from .nvmrc
+        run: echo NVMRC=`cat .nvmrc` >> $GITHUB_ENV
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: ${{ env.NVMRC }}
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
         with:


### PR DESCRIPTION
Since `semantic-release` command requires Node v18 or above, we need to update the Node version in the release workflow.