### PR TITLE
feat!: drop Node v14 and v16 support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18, 19]
+        node: [18, 20]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "node_modules"
   ],
   "engines": {
-    "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
-    "npm": ">=6",
+    "node": "^18.0.0 || >=20.0.0",
+    "npm": ">=9",
     "yarn": ">=1"
   },
   "engineStrict": true,


### PR DESCRIPTION
BREAKING CHANGE: Node versions 14 and 16 are no longer supported. Please switch to Node v18 or v20. 